### PR TITLE
Enforce rules

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -18,6 +18,7 @@ pub enum PieceType {
 pub struct Piece {
     pub piece_type: PieceType,
     pub owner: Player,
+    pub promoted: bool,
 }
 
 // [行(y)][列(x)]
@@ -136,12 +137,14 @@ pub fn init() -> GameState {
         board[0][x] = Some(Piece {
             piece_type: pt,
             owner: Player::Gote,
+            promoted: false,
         });
     }
 
     board[1][0] = Some(Piece {
         piece_type: PieceType::Pawn,
         owner: Player::Gote,
+        promoted: false,
     });
 
     // 先手
@@ -157,12 +160,14 @@ pub fn init() -> GameState {
         board[4][x] = Some(Piece {
             piece_type: pt,
             owner: Player::Sente,
+            promoted: false,
         });
     }
 
     board[3][4] = Some(Piece {
         piece_type: PieceType::Pawn,
         owner: Player::Sente,
+        promoted: false,
     });
 
     GameState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ fn main() {
         loop {
             println!("\n入力形式:");
             println!("  移動: <from> <to> (例: 1e 1d)");
+            println!("  成り: <from> <to>+ (例: 1e 1d+)");
             println!("  打つ: drop <駒> <to> (例: drop 金 3c)");
             println!("  終了: quit");
             print!("> ");
@@ -87,13 +88,19 @@ fn parse_input(input: &str, legal_moves: &[rules::Move]) -> Result<rules::Move, 
         rules::Move::Drop(to, piece_type)
     } else {
         if parts.len() != 2 {
-            return Err("移動の形式: <from> <to>".to_string());
+            return Err("移動の形式: <from> <to> または <from> <to>+".to_string());
         }
 
         let from = parse_position(parts[0])?;
-        let to = parse_position(parts[1])?;
+        let promote = parts[1].ends_with('+');
+        let to_str = if promote {
+            &parts[1][..parts[1].len() - 1]
+        } else {
+            parts[1]
+        };
+        let to = parse_position(to_str)?;
 
-        rules::Move::To(from, to)
+        rules::Move::To(from, to, promote)
     };
 
     if !legal_moves.contains(&mv) {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -14,11 +14,29 @@ impl Position {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Move {
-    To(Position, Position),    // (from, to)
-    Drop(Position, PieceType), // (to, type)
+    To(Position, Position, bool), // (from, to, promote)
+    Drop(Position, PieceType),    // (to, type)
 }
 
 pub fn generate_legal_moves(state: &GameState, player: Player) -> Vec<Move> {
+    let mut moves = generate_moves(state, player);
+
+    // 打ち歩詰めチェック: 歩のdropで相手が詰みになる手を除外
+    let opponent = opponent_of(player);
+    moves.retain(|mv| {
+        if let Move::Drop(_, PieceType::Pawn) = mv {
+            let new_state = make_move(state, *mv, player);
+            !is_checkmate(&new_state, opponent)
+        } else {
+            true
+        }
+    });
+
+    moves
+}
+
+/// 二歩チェック付きの手生成（打ち歩詰めチェックなし）
+fn generate_moves(state: &GameState, player: Player) -> Vec<Move> {
     let mut moves = Vec::new();
 
     for y in 0..5 {
@@ -27,7 +45,14 @@ pub fn generate_legal_moves(state: &GameState, player: Player) -> Vec<Move> {
                 && piece.owner == player
             {
                 let from = Position::new(x, y);
-                add_move_for_piece(&mut moves, &state.board, player, piece.piece_type, from);
+                add_move_for_piece(
+                    &mut moves,
+                    &state.board,
+                    player,
+                    piece.piece_type,
+                    piece.promoted,
+                    from,
+                );
             }
         }
     }
@@ -41,11 +66,28 @@ pub fn generate_legal_moves(state: &GameState, player: Player) -> Vec<Move> {
         PieceType::Rook,
     ];
 
+    // 二歩チェック用: 各列に自分の未成り歩があるか事前計算
+    let mut pawn_columns = [false; 5];
+    for row in &state.board {
+        for (x, cell) in row.iter().enumerate() {
+            if let Some(piece) = cell
+                && piece.piece_type == PieceType::Pawn
+                && piece.owner == player
+                && !piece.promoted
+            {
+                pawn_columns[x] = true;
+            }
+        }
+    }
+
     for &piece_type in &piece_types {
         if hand.get(piece_type) > 0 {
-            for y in 0..5 {
-                for x in 0..5 {
-                    if state.board[y][x].is_none() {
+            for (y, row) in state.board.iter().enumerate() {
+                for (x, cell) in row.iter().enumerate() {
+                    if cell.is_none() {
+                        if piece_type == PieceType::Pawn && pawn_columns[x] {
+                            continue;
+                        }
                         moves.push(Move::Drop(Position::new(x, y), piece_type));
                     }
                 }
@@ -61,26 +103,46 @@ fn add_move_for_piece(
     board: &Board,
     player: Player,
     p_type: PieceType,
+    promoted: bool,
     from: Position,
 ) {
-    match p_type {
-        PieceType::Rook => {
-            let dirs = [(0, -1), (0, 1), (-1, 0), (1, 0)];
-            add_sliding_moves(moves, board, player, from, &dirs);
-        }
-        PieceType::Bishop => {
-            let dirs = [(-1, -1), (-1, 1), (1, -1), (1, 1)];
-            add_sliding_moves(moves, board, player, from, &dirs);
-        }
-        _ => {
-            let offsets = get_stepping_offsets(player, p_type);
-            add_stepping_moves(moves, board, player, from, &offsets);
+    let destinations = collect_piece_destinations(board, player, p_type, promoted, from);
+    let can_promote = !promoted && can_piece_promote(p_type);
+
+    for to in destinations {
+        if can_promote && (is_in_promotion_zone(player, from.y) || is_in_promotion_zone(player, to.y))
+        {
+            moves.push(Move::To(from, to, true));
+            // 歩が最奥段に到達した場合は強制成り（不成の選択肢なし）
+            if !must_promote(player, p_type, to.y) {
+                moves.push(Move::To(from, to, false));
+            }
+        } else {
+            moves.push(Move::To(from, to, false));
         }
     }
 }
 
-fn add_stepping_moves(
-    moves: &mut Vec<Move>,
+fn can_piece_promote(p_type: PieceType) -> bool {
+    matches!(
+        p_type,
+        PieceType::Pawn | PieceType::Silver | PieceType::Bishop | PieceType::Rook
+    )
+}
+
+fn is_in_promotion_zone(player: Player, y: usize) -> bool {
+    match player {
+        Player::Sente => y == 0,
+        Player::Gote => y == 4,
+    }
+}
+
+fn must_promote(player: Player, p_type: PieceType, to_y: usize) -> bool {
+    p_type == PieceType::Pawn && is_in_promotion_zone(player, to_y)
+}
+
+fn collect_stepping_moves(
+    destinations: &mut Vec<Position>,
     board: &Board,
     player: Player,
     from: Position,
@@ -90,13 +152,13 @@ fn add_stepping_moves(
         if let Some(to) = apply_offset(from, dx, dy)
             && !is_friendly_piece(board, to, player)
         {
-            moves.push(Move::To(from, to));
+            destinations.push(to);
         }
     }
 }
 
-fn add_sliding_moves(
-    moves: &mut Vec<Move>,
+fn collect_sliding_moves(
+    destinations: &mut Vec<Position>,
     board: &Board,
     player: Player,
     from: Position,
@@ -107,11 +169,11 @@ fn add_sliding_moves(
         while let Some(next) = apply_offset(curr, dx, dy) {
             if let Some(target_piece) = board[next.y][next.x] {
                 if target_piece.owner != player {
-                    moves.push(Move::To(from, next));
+                    destinations.push(next);
                 }
                 break;
             } else {
-                moves.push(Move::To(from, next));
+                destinations.push(next);
                 curr = next;
             }
         }
@@ -187,16 +249,137 @@ fn get_stepping_offsets(player: Player, p_type: PieceType) -> Vec<(i8, i8)> {
     offsets
 }
 
+fn opponent_of(player: Player) -> Player {
+    match player {
+        Player::Sente => Player::Gote,
+        Player::Gote => Player::Sente,
+    }
+}
+
+fn find_king(state: &GameState, player: Player) -> Option<Position> {
+    for y in 0..5 {
+        for x in 0..5 {
+            if let Some(piece) = state.board[y][x]
+                && piece.piece_type == PieceType::King
+                && piece.owner == player
+            {
+                return Some(Position::new(x, y));
+            }
+        }
+    }
+    None
+}
+
+fn collect_piece_destinations(
+    board: &Board,
+    player: Player,
+    p_type: PieceType,
+    promoted: bool,
+    from: Position,
+) -> Vec<Position> {
+    let mut destinations = Vec::new();
+
+    if promoted {
+        match p_type {
+            PieceType::Rook => {
+                let dirs = [(0, -1), (0, 1), (-1, 0), (1, 0)];
+                collect_sliding_moves(&mut destinations, board, player, from, &dirs);
+                let diag = [(-1, -1), (-1, 1), (1, -1), (1, 1)];
+                collect_stepping_moves(&mut destinations, board, player, from, &diag);
+            }
+            PieceType::Bishop => {
+                let dirs = [(-1, -1), (-1, 1), (1, -1), (1, 1)];
+                collect_sliding_moves(&mut destinations, board, player, from, &dirs);
+                let ortho = [(0, -1), (0, 1), (-1, 0), (1, 0)];
+                collect_stepping_moves(&mut destinations, board, player, from, &ortho);
+            }
+            PieceType::Pawn | PieceType::Silver => {
+                let offsets = get_stepping_offsets(player, PieceType::Gold);
+                collect_stepping_moves(&mut destinations, board, player, from, &offsets);
+            }
+            _ => {}
+        }
+    } else {
+        match p_type {
+            PieceType::Rook => {
+                let dirs = [(0, -1), (0, 1), (-1, 0), (1, 0)];
+                collect_sliding_moves(&mut destinations, board, player, from, &dirs);
+            }
+            PieceType::Bishop => {
+                let dirs = [(-1, -1), (-1, 1), (1, -1), (1, 1)];
+                collect_sliding_moves(&mut destinations, board, player, from, &dirs);
+            }
+            _ => {
+                let offsets = get_stepping_offsets(player, p_type);
+                collect_stepping_moves(&mut destinations, board, player, from, &offsets);
+            }
+        }
+    }
+
+    destinations
+}
+
+fn is_in_check(state: &GameState, player: Player) -> bool {
+    let king_pos = match find_king(state, player) {
+        Some(pos) => pos,
+        None => return false,
+    };
+
+    let opponent = opponent_of(player);
+
+    for y in 0..5 {
+        for x in 0..5 {
+            if let Some(piece) = state.board[y][x]
+                && piece.owner == opponent
+            {
+                let from = Position::new(x, y);
+                let dests = collect_piece_destinations(
+                    &state.board,
+                    opponent,
+                    piece.piece_type,
+                    piece.promoted,
+                    from,
+                );
+                if dests.iter().any(|d| d.x == king_pos.x && d.y == king_pos.y) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+fn is_checkmate(state: &GameState, player: Player) -> bool {
+    if !is_in_check(state, player) {
+        return false;
+    }
+
+    let moves = generate_moves(state, player);
+    for mv in moves {
+        let new_state = make_move(state, mv, player);
+        if !is_in_check(&new_state, player) {
+            return false;
+        }
+    }
+
+    true
+}
+
 pub fn make_move(state: &GameState, mv: Move, player: Player) -> GameState {
     let mut new_state = *state;
 
     match mv {
-        Move::To(from, to) => {
-            let piece =
+        Move::To(from, to, promote) => {
+            let mut piece =
                 new_state.board[from.y][from.x].expect("move_from position should have a piece");
 
             if let Some(captured) = new_state.board[to.y][to.x] {
                 new_state.get_hand_mut(player).add(captured.piece_type);
+            }
+
+            if promote {
+                piece.promoted = true;
             }
 
             new_state.board[to.y][to.x] = Some(piece);
@@ -207,6 +390,7 @@ pub fn make_move(state: &GameState, mv: Move, player: Player) -> GameState {
                 let piece = Piece {
                     piece_type,
                     owner: player,
+                    promoted: false,
                 };
                 new_state.board[to.y][to.x] = Some(piece);
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,13 +13,23 @@ pub fn print_board(board: &Board) {
             match cell {
                 Some(p) => {
                     let owner_mark = if p.owner == Player::Sente { " " } else { "^" };
-                    let name = match p.piece_type {
-                        PieceType::King => "王",
-                        PieceType::Gold => "金",
-                        PieceType::Silver => "銀",
-                        PieceType::Bishop => "角",
-                        PieceType::Rook => "飛",
-                        PieceType::Pawn => "歩",
+                    let name = if p.promoted {
+                        match p.piece_type {
+                            PieceType::Pawn => "と",
+                            PieceType::Silver => "全",
+                            PieceType::Bishop => "馬",
+                            PieceType::Rook => "龍",
+                            _ => unreachable!(),
+                        }
+                    } else {
+                        match p.piece_type {
+                            PieceType::King => "王",
+                            PieceType::Gold => "金",
+                            PieceType::Silver => "銀",
+                            PieceType::Bishop => "角",
+                            PieceType::Rook => "飛",
+                            PieceType::Pawn => "歩",
+                        }
                     };
                     print!("{}{}|", owner_mark, name);
                 }


### PR DESCRIPTION
変更ファイルと内容                                                                                                                                                                                             
                                                                                                                                                                                                                 
  src/board.rs                                                                                                                                                                                                   
  - Piece に promoted: bool フィールドを追加                                                                                                                                                                     
  - 初期配置で全駒を promoted: false に設定                                                                                                                                                                      
                                                                                                                                                                                                                 
  src/rules.rs                                                                                                                                                                                                   
  - Move::To に成りフラグ bool を追加 → To(Position, Position, bool)                                                                                                                                             
  - collect_piece_destinations を共通関数として抽出し、成り駒の動きを実装:                                                                                                                                       
    - と金・成銀 → 金の動き                                                                                                                                                                                      
    - 馬 → 角 + 上下左右1マス                                                                                                                                                                                    
    - 龍 → 飛車 + 斜め1マス                                                                                                                                                                                      
  - 成りゾーン（先手: y=0, 後手: y=4）での成り/不成の選択肢を生成、歩の最奥段は強制成り                                                                                                                          
  - 二歩チェック: 事前に列ごとの未成り歩の有無を配列で計算                                                                                                                                                       
  - 打ち歩詰め: find_king / is_in_check / is_checkmate ヘルパーを追加し、歩dropで即詰みになる手を retain で除外                                                                                                  
                                                                                                                                                                                                                 
  src/ui.rs                                                                                                                                                                                                      
  - 成り駒の表示対応（と/全/馬/龍）                                                                                                                                                                              
                                                                                                                                                                                                                 
  src/main.rs                                                                                                                                                                                                    
  - 入力形式に <from> <to>+（成り）を追加                                                                                                                                                                        
  - + 付き入力のパースを parse_input に追加            